### PR TITLE
Performance: `get_outs` is called just once per a transaction

### DIFF
--- a/check_clsag.py
+++ b/check_clsag.py
@@ -27,7 +27,7 @@ import settings
 def ring_sig_correct_bp1(h, resp_json, resp_hex, txs, i_tx, inputs, outputs, details):
     rows = len(resp_json["vin"][0]["key"]["key_offsets"])
     message = get_tx_hash_clsag(resp_json, resp_hex)
-    pubs,masks = misc_func.get_members_and_masks_in_ring(resp_json,inputs,rows)
+    pubs, masks = misc_func.get_members_and_masks_in_rings(resp_json)
 
     str_ki = []
     for sig_ind in range(inputs):
@@ -102,7 +102,7 @@ def ring_sig_correct_bp_plus(
 ):
     rows = len(resp_json["vin"][0]["key"]["key_offsets"])
     message = get_tx_hash_clsag_bp_plus(resp_json, resp_hex)
-    pubs,masks = misc_func.get_members_and_masks_in_ring(resp_json,inputs,rows)
+    pubs, masks = misc_func.get_members_and_masks_in_rings(resp_json)
 
     str_ki = []
     for sig_ind in range(inputs):

--- a/check_mlsag.py
+++ b/check_mlsag.py
@@ -18,7 +18,7 @@ from concurrent.futures import as_completed, ProcessPoolExecutor
 def ring_sig_correct(h, resp_json, resp_hex, txs, i_tx, inputs, outputs, details):
     rows = len(resp_json["vin"][0]["key"]["key_offsets"])
     message = get_tx_hash_mlsag(resp_json, resp_hex)
-    pubs, masks = misc_func.get_members_and_masks_in_ring(resp_json,inputs,rows)
+    pubs, masks = misc_func.get_members_and_masks_in_rings(resp_json)
     str_ki = []
     for sig_ind in range(inputs):
         Iv = Point(resp_json["vin"][sig_ind]["key"]["k_image"])
@@ -94,7 +94,7 @@ def ring_sig_correct(h, resp_json, resp_hex, txs, i_tx, inputs, outputs, details
 def ring_sig_correct_bp1(h, resp_json, resp_hex, txs, i_tx, inputs, outputs, details):
     rows = len(resp_json["vin"][0]["key"]["key_offsets"])
     message = get_tx_hash_bp1(resp_json, resp_hex)
-    pubs, masks = misc_func.get_members_and_masks_in_ring(resp_json,inputs,rows)
+    pubs, masks = misc_func.get_members_and_masks_in_rings(resp_json)
     str_ki = []
     for sig_ind in range(inputs):
         Iv = Point(resp_json["vin"][sig_ind]["key"]["k_image"])


### PR DESCRIPTION
* `com_db.get_members_and_masks()` accepts a list of inputs, returning a list of outputs
* All outputs in a transaction are retrieved in one call
* Removed some unused code

The performance gain is slight (3 %) when using localhost daemon but it is twice as fast if an external node is used.