### PR TITLE
Bugfix: Choosing node (localhost/public) does not work

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -34,7 +34,7 @@ Gi_plus = PointVector(np.load("Gi_plus.npy", allow_pickle=True))
 
 
 def node_choice(choice):
-    global node_conn
+    global node_conn, url_str
 
     node_conn = copy.copy(choice)
 


### PR DESCRIPTION
Choosing a node (localhost/public) did nothing; the pre-set node was always used instead.
(In code, only a local variable was set, and never used anymore.)